### PR TITLE
Few minor change

### DIFF
--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -608,16 +608,6 @@ let parse_value value =
   | Ok _ as ok -> ok
   | Error _ -> Error (Format.sprintf "value: %s" value)
 
-let parse_max_age max_age =
-  match max_age with
-  | None -> Ok None
-  | Some ma ->
-      if ma <= 0L then
-        Error
-          (Format.sprintf
-             "Cookies 'Max-Age' attribute is less than or equal to 0")
-      else Ok (Some ma)
-
 let parse_opt ?error_label p input =
   match input with
   | Some input -> (
@@ -660,7 +650,6 @@ let create ?path ?domain ?expires ?max_age ?(secure = false) ?(http_only = true)
   let* value = parse_value value in
   let* domain = parse_opt ~error_label:"domain" domain_value domain in
   let* path = parse_opt ~error_label:"path" path_value path in
-  let* max_age = parse_max_age max_age in
   let+ extension =
     parse_opt ~error_label:"extension" extension_value extension
   in
@@ -777,7 +766,6 @@ let update_domain domain cookie =
 let update_expires expires cookie = { cookie with expires }
 
 let update_max_age max_age cookie =
-  let+ max_age = parse_max_age max_age in
   { cookie with max_age }
 
 let update_secure secure cookie = { cookie with secure }

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -276,7 +276,7 @@ let domain_name =
   *)
   let* () = option () (char '.' *> return ()) in
   let* start_pos = pos in
-  let* subdomain = subdomain in
+  let* subdomain in
   let* end_pos = pos in
   let len = end_pos - start_pos in
   if len > 255 then
@@ -550,7 +550,9 @@ let http_date =
   rfc1123_date
 
 let max_age_value =
-  let digit_or_minus = satisfy (function '-' | '0' .. '9' -> true | _ -> false) in
+  let digit_or_minus =
+    satisfy (function '-' | '0' .. '9' -> true | _ -> false)
+  in
   let* first_char = digit_or_minus in
   let* digits = take_while is_digit in
   let max_age = Format.sprintf "%c%s" first_char digits in
@@ -717,9 +719,7 @@ let to_set_cookie t =
   O.iter
     (fun expires -> add_str "; Expires=%s" @@ date_to_string expires)
     t.expires;
-  O.iter
-    (fun max_age -> add_str "; Max-Age=%Ld" max_age)
-    t.max_age;
+  O.iter (fun max_age -> add_str "; Max-Age=%Ld" max_age) t.max_age;
   if t.secure then add_str "; Secure";
   if t.http_only then add_str "; HttpOnly";
   O.iter
@@ -799,7 +799,8 @@ let update_extension extension cookie =
   { cookie with extension }
 
 let expire cookie =
-  { cookie with
+  {
+    cookie with
     value = "";
     path = None;
     domain = None;

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -780,8 +780,6 @@ let expire cookie =
   {
     cookie with
     value = "";
-    path = None;
-    domain = None;
     expires = None;
     max_age = Some (-1L);
     extension = None;

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -798,7 +798,7 @@ let update_extension extension cookie =
   let+ extension = parse_opt extension_value extension in
   { cookie with extension }
 
-let delete cookie =
+let expire cookie =
   { cookie with
     value = "";
     path = None;

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -596,17 +596,7 @@ let set_cookie_string =
 *)
 let cookie_string =
   let* cookies = sep_by1 (char ';' *> char '\x20') cookie_pair in
-  let name_counts = Hashtbl.create 0 in
-  List.iter
-    (fun (name, _) ->
-      match Hashtbl.find_opt name_counts name with
-      | Some count -> Hashtbl.replace name_counts name (count + 1)
-      | None -> Hashtbl.replace name_counts name 1)
-    cookies;
-  let name_counts = Hashtbl.to_seq_values name_counts |> List.of_seq in
-  if List.exists (fun count -> count > 1) name_counts then
-    fail "duplicate cookies found"
-  else return cookies
+  return cookies
 
 let parse_name name =
   parse_string ~consume:Consume.All cookie_name name |> function

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -797,3 +797,13 @@ let update_same_site same_site cookie = { cookie with same_site }
 let update_extension extension cookie =
   let+ extension = parse_opt extension_value extension in
   { cookie with extension }
+
+let delete cookie =
+  { cookie with
+    value = "";
+    path = None;
+    domain = None;
+    expires = None;
+    max_age = Some (-1L);
+    extension = None;
+  }

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -550,8 +550,8 @@ let http_date =
   rfc1123_date
 
 let max_age_value =
-  let non_zero_digit_or_minus = satisfy (function '-' | '1' .. '9' -> true | _ -> false) in
-  let* first_char = non_zero_digit_or_minus in
+  let digit_or_minus = satisfy (function '-' | '0' .. '9' -> true | _ -> false) in
+  let* first_char = digit_or_minus in
   let* digits = take_while is_digit in
   let max_age = Format.sprintf "%c%s" first_char digits in
   try return (Int64.of_string max_age)

--- a/lib/http_cookie.ml
+++ b/lib/http_cookie.ml
@@ -550,8 +550,8 @@ let http_date =
   rfc1123_date
 
 let max_age_value =
-  let non_zero_digit = satisfy (function '1' .. '9' -> true | _ -> false) in
-  let* first_char = non_zero_digit in
+  let non_zero_digit_or_minus = satisfy (function '-' | '1' .. '9' -> true | _ -> false) in
+  let* first_char = non_zero_digit_or_minus in
   let* digits = take_while is_digit in
   let max_age = Format.sprintf "%c%s" first_char digits in
   try return (Int64.of_string max_age)
@@ -718,7 +718,7 @@ let to_set_cookie t =
     (fun expires -> add_str "; Expires=%s" @@ date_to_string expires)
     t.expires;
   O.iter
-    (fun max_age -> if max_age > 0L then add_str "; Max-Age=%Ld" max_age)
+    (fun max_age -> add_str "; Max-Age=%Ld" max_age)
     t.max_age;
   if t.secure then add_str "; Secure";
   if t.http_only then add_str "; HttpOnly";

--- a/lib/http_cookie.mli
+++ b/lib/http_cookie.mli
@@ -224,6 +224,7 @@ val update_http_only : bool -> t -> t
 val update_same_site : same_site option -> t -> t
 val update_extension : string option -> t -> (t, string) result
 
-(** mark the Cookie with a negative max-age, remove now useless payload.
-    The cookie still needs to be send to client for it to delete the cookie. *)
-val delete : t -> t
+val expire : t -> t
+(** [expire c] marks the cookie with a negative max-age, remove now useless
+    payload.  The cookie still needs to be send to client for it to delete the
+    cookie. *)

--- a/lib/http_cookie.mli
+++ b/lib/http_cookie.mli
@@ -223,3 +223,7 @@ val update_secure : bool -> t -> t
 val update_http_only : bool -> t -> t
 val update_same_site : same_site option -> t -> t
 val update_extension : string option -> t -> (t, string) result
+
+(** mark the Cookie with a negative max-age, remove now useless payload.
+    The cookie still needs to be send to client for it to delete the cookie. *)
+val delete : t -> t

--- a/lib/http_cookie.mli
+++ b/lib/http_cookie.mli
@@ -226,5 +226,5 @@ val update_extension : string option -> t -> (t, string) result
 
 val expire : t -> t
 (** [expire c] marks the cookie with a negative max-age, remove now useless
-    payload.  The cookie still needs to be send to client for it to delete the
+    payload. The cookie still needs to be send to client for it to delete the
     cookie. *)

--- a/lib/http_cookie.mli
+++ b/lib/http_cookie.mli
@@ -218,7 +218,7 @@ val update_name : string -> t -> (t, string) result
 val update_path : string option -> t -> (t, string) result
 val update_domain : string option -> t -> (t, string) result
 val update_expires : date_time option -> t -> t
-val update_max_age : int64 option -> t -> (t, string) result
+val update_max_age : int64 option -> t -> t
 val update_secure : bool -> t -> t
 val update_http_only : bool -> t -> t
 val update_same_site : same_site option -> t -> t

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -461,6 +461,44 @@ let%expect_test "of_set_cookie: " =
     same_site:
     extension: |}]
 
+(* of_set_cookie tests *)
+let%expect_test "of_set_cookie: " =
+  Http_cookie.of_set_cookie
+    "SID=31d4d96e407aad42; Path=/; Domain=example.com; Secure; HttpOnly; \
+     Max-Age=-1"
+  |> pp_t;
+  [%expect
+    {|
+    name: SID
+    value: 31d4d96e407aad42
+    path: /
+    domain: example.com
+    expires:
+    max_age: -1
+    secure: true
+    http_only: true
+    same_site:
+    extension: |}]
+
+(* of_set_cookie tests *)
+let%expect_test "of_set_cookie: " =
+  Http_cookie.of_set_cookie
+    "SID=31d4d96e407aad42; Path=/; Domain=example.com; Secure; HttpOnly; \
+     Max-Age=0"
+  |> pp_t;
+  [%expect
+    {|
+    name: SID
+    value: 31d4d96e407aad42
+    path: /
+    domain: example.com
+    expires:
+    max_age: 0
+    secure: true
+    http_only: true
+    same_site:
+    extension: |}]
+
 let%expect_test "of_set_cookie: " =
   Http_cookie.of_set_cookie
     "SID=31d4d96e407aad42; Path=/; Domain=192.169.0.1; Secure; HttpOnly; \

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -614,3 +614,27 @@ let%expect_test "delete" =
   |> pp_to_set_cookie;
   [%expect
     {| hello=; Max-Age=-1; HttpOnly; SameSite=None |}]
+
+
+let%expect_test "delete" =
+  let expires =
+    Http_cookie.date_time ~year:2021 ~month:`Jan ~weekday:`Mon ~day:12 ~hour:23
+      ~minutes:23 ~seconds:59
+    |> Result.get_ok
+  in
+  Http_cookie.create ~path:"/home/about" ~domain:"198.168.0.1" ~expires
+    ~max_age:2342342L ~same_site:`Strict ~name:"h" "value2"
+  |> Result.get_ok
+  |> Http_cookie.delete
+  |> pp_to_set_cookie;
+  [%expect
+    {| h=; Max-Age=-1; HttpOnly; SameSite=Strict |}]
+
+let%expect_test "delete" =
+  Http_cookie.create ~domain:"198.168.0.1"
+    ~same_site:`Lax ~name:"h" ~http_only:false ""
+  |> Result.get_ok
+  |> Http_cookie.delete
+  |> pp_to_set_cookie;
+  [%expect
+    {| h=; Max-Age=-1; SameSite=Lax |}]

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -639,7 +639,7 @@ let%expect_test "to_set_cookie" =
   [%expect
     {| hello=value1; Path=/home/about; Domain=198.168.0.1; Expires=Mon, 12 Jan 2021 23:23:59 GMT; Max-Age=2342342; HttpOnly; SameSite=None |}]
 
-let%expect_test "delete" =
+let%expect_test "expire" =
   let expires =
     Http_cookie.date_time ~year:2021 ~month:`Jan ~weekday:`Mon ~day:12 ~hour:23
       ~minutes:23 ~seconds:59
@@ -648,13 +648,13 @@ let%expect_test "delete" =
   Http_cookie.create ~path:"/home/about" ~domain:"198.168.0.1" ~expires
     ~max_age:2342342L ~same_site:`None ~name:"hello" "value1"
   |> Result.get_ok
-  |> Http_cookie.delete
+  |> Http_cookie.expire
   |> pp_to_set_cookie;
   [%expect
     {| hello=; Max-Age=-1; HttpOnly; SameSite=None |}]
 
 
-let%expect_test "delete" =
+let%expect_test "expire" =
   let expires =
     Http_cookie.date_time ~year:2021 ~month:`Jan ~weekday:`Mon ~day:12 ~hour:23
       ~minutes:23 ~seconds:59
@@ -663,16 +663,16 @@ let%expect_test "delete" =
   Http_cookie.create ~path:"/home/about" ~domain:"198.168.0.1" ~expires
     ~max_age:2342342L ~same_site:`Strict ~name:"h" "value2"
   |> Result.get_ok
-  |> Http_cookie.delete
+  |> Http_cookie.expire
   |> pp_to_set_cookie;
   [%expect
     {| h=; Max-Age=-1; HttpOnly; SameSite=Strict |}]
 
-let%expect_test "delete" =
+let%expect_test "expire" =
   Http_cookie.create ~domain:"198.168.0.1"
     ~same_site:`Lax ~name:"h" ~http_only:false ""
   |> Result.get_ok
-  |> Http_cookie.delete
+  |> Http_cookie.expire
   |> pp_to_set_cookie;
   [%expect
     {| h=; Max-Age=-1; SameSite=Lax |}]

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -650,9 +650,7 @@ let%expect_test "expire" =
   |> Result.get_ok
   |> Http_cookie.expire
   |> pp_to_set_cookie;
-  [%expect
-    {| hello=; Max-Age=-1; HttpOnly; SameSite=None |}]
-
+  [%expect {| hello=; Max-Age=-1; HttpOnly; SameSite=None |}]
 
 let%expect_test "expire" =
   let expires =
@@ -665,14 +663,12 @@ let%expect_test "expire" =
   |> Result.get_ok
   |> Http_cookie.expire
   |> pp_to_set_cookie;
-  [%expect
-    {| h=; Max-Age=-1; HttpOnly; SameSite=Strict |}]
+  [%expect {| h=; Max-Age=-1; HttpOnly; SameSite=Strict |}]
 
 let%expect_test "expire" =
-  Http_cookie.create ~domain:"198.168.0.1"
-    ~same_site:`Lax ~name:"h" ~http_only:false ""
+  Http_cookie.create ~domain:"198.168.0.1" ~same_site:`Lax ~name:"h"
+    ~http_only:false ""
   |> Result.get_ok
   |> Http_cookie.expire
   |> pp_to_set_cookie;
-  [%expect
-    {| h=; Max-Age=-1; SameSite=Lax |}]
+  [%expect {| h=; Max-Age=-1; SameSite=Lax |}]

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -600,3 +600,17 @@ let%expect_test "to_set_cookie" =
   |> pp_to_set_cookie;
   [%expect
     {| hello=value1; Path=/home/about; Domain=198.168.0.1; Expires=Mon, 12 Jan 2021 23:23:59 GMT; Max-Age=2342342; HttpOnly; SameSite=None |}]
+
+let%expect_test "delete" =
+  let expires =
+    Http_cookie.date_time ~year:2021 ~month:`Jan ~weekday:`Mon ~day:12 ~hour:23
+      ~minutes:23 ~seconds:59
+    |> Result.get_ok
+  in
+  Http_cookie.create ~path:"/home/about" ~domain:"198.168.0.1" ~expires
+    ~max_age:2342342L ~same_site:`None ~name:"hello" "value1"
+  |> Result.get_ok
+  |> Http_cookie.delete
+  |> pp_to_set_cookie;
+  [%expect
+    {| hello=; Max-Age=-1; HttpOnly; SameSite=None |}]


### PR DESCRIPTION
- expire should no reset domain and path
- non positive max_age are legal (a way to expire a cookie, and it could be expired by client in js)
- duplicate cookie are possible, with distinct path, domain and other situations. Currently this can completely break a session.
